### PR TITLE
Фильтр выбора категории `layf_category_filter`

### DIFF
--- a/inc/feed.php
+++ b/inc/feed.php
@@ -38,7 +38,8 @@ echo '<?xml version="1.0" encoding="'.get_option('blog_charset').'"?>';
 <?php endif;?>
 <?php
 	$category_tax = apply_filters('layf_category_taxonomy', 'category', get_the_ID());
-    $category = wp_get_object_terms(get_the_ID(), $category_tax);
+    $categories = wp_get_object_terms(get_the_ID(), $category_tax);
+    $category = apply_filters('layf_category_filter', $categories);
     if(count($category) > 1 && $category[0]->slug == 'uncategorized')
         $category = $category[1]->name;
     else


### PR DESCRIPTION
В случае, когда категорий больше чем одна — нужна возможность их
выбирать по определенным условиям. Теперь достаточно создать фильтр
`layf_category_filter` в functiuons.php и в нем, к примеру, удалить
лишние категории. Если фильтра нет, то логика работы приложения будет
прежней — выберется первая категория

Пример фильтра в functions.php:

``` php
function filter_category($category) {
    foreach($category as $k => $c) {
        if ($c->name == 'Не та категория')
            unset($category[$k]);
    }
    return $category;
}
add_filter('layf_category_filter', 'filter_category');
```
