### PR TITLE
do_action at the end of RSS item

### DIFF
--- a/inc/feed.php
+++ b/inc/feed.php
@@ -126,7 +126,7 @@ if(!empty($logo)):
 <turbo:content><?php echo La_Yandex_Feed_Core::get_the_turbo_content();?></turbo:content>
 <?php endif?>
 <yandex:full-text><?php echo La_Yandex_Feed_Core::get_the_content_feed(); ?></yandex:full-text>
-<?php do_action( 'layf_rss_item' ); ?>
+<?php do_action( 'layf_rss_item', get_the_ID(), $is_show_turbo ); ?>
 </item>
 <?php endwhile; ?>
 </channel>

--- a/inc/feed.php
+++ b/inc/feed.php
@@ -126,6 +126,7 @@ if(!empty($logo)):
 <turbo:content><?php echo La_Yandex_Feed_Core::get_the_turbo_content();?></turbo:content>
 <?php endif?>
 <yandex:full-text><?php echo La_Yandex_Feed_Core::get_the_content_feed(); ?></yandex:full-text>
+<?php do_action( 'layf_rss_item' ); ?>
 </item>
 <?php endwhile; ?>
 </channel>


### PR DESCRIPTION
Возникла нужда добавить свой собственный счетчик к турбо-страницам (Метрика не подошла).

Кажется, этот экшен — простейший и наиболее аккуратный способ включить кастомные теги в RSS.